### PR TITLE
Feint fixes

### DIFF
--- a/DragonFixes/FixList.txt
+++ b/DragonFixes/FixList.txt
@@ -81,3 +81,4 @@
 - Fix Bite of the Vampire (Bloodseeker feature) to work on sneak attacks
 - Shadowblood now applies -4 compulusion effect correctly
 - Fix Favored Terrain from not applying after first loading a save
+- Fix Slayer's Feint not working: its skill checks were rolled by the target instead of the caster (CheckForCaster was false)

--- a/DragonFixes/FixList.txt
+++ b/DragonFixes/FixList.txt
@@ -82,3 +82,4 @@
 - Shadowblood now applies -4 compulusion effect correctly
 - Fix Favored Terrain from not applying after first loading a save
 - Fix Slayer's Feint not working: its skill checks were rolled by the target instead of the caster (CheckForCaster was false), and the Mobility path applied the wrong marker so Final Feint never triggered on it
+- Fix the Feint DC to use the target's Perception-based DC when it is higher than the BAB-based DC, instead of always using the lower BAB DC (affects all feints; makes feinting appropriately harder)

--- a/DragonFixes/FixList.txt
+++ b/DragonFixes/FixList.txt
@@ -81,4 +81,4 @@
 - Fix Bite of the Vampire (Bloodseeker feature) to work on sneak attacks
 - Shadowblood now applies -4 compulusion effect correctly
 - Fix Favored Terrain from not applying after first loading a save
-- Fix Slayer's Feint not working: its skill checks were rolled by the target instead of the caster (CheckForCaster was false)
+- Fix Slayer's Feint not working: its skill checks were rolled by the target instead of the caster (CheckForCaster was false), and the Mobility path applied the wrong marker so Final Feint never triggered on it

--- a/DragonFixes/Fixes/VariousFixes/FeintFixes.cs
+++ b/DragonFixes/Fixes/VariousFixes/FeintFixes.cs
@@ -11,11 +11,15 @@ using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Buffs.Blueprints;
 using Kingmaker.UnitLogic.Mechanics.Actions;
 using Kingmaker.UnitLogic.Mechanics.Conditions;
+using Kingmaker.UnitLogic.Mechanics.Properties;
 using TabletopTweaks.Core.Utilities;
 
 namespace DragonFixes.Fixes.VariousFixes;
 
-public class SlayersFeintFix
+// All of these fixes edit the single shared FeintAbility blueprint. The first two are gated behind
+// the "slayerfeintfix" toggle because they only change behaviour for Slayer's Feint; the third
+// (FixFeintDcUsesPerceptionWhenHigher) is a general feint fix and has its own toggle.
+public class FeintFixes
 {
     [DragonConfigure]
     public static void FixFeintCheckForCaster()
@@ -81,6 +85,48 @@ public class SlayersFeintFix
         }
     }
 
+    [DragonConfigure]
+    public static void FixFeintDcUsesPerceptionWhenHigher()
+    {
+        if (!Settings.GetSetting<bool>("feintdcfix"))
+        {
+            Main.log.Log("Feint DC patch disabled, skipping.");
+            return;
+        }
+        // The feint DC is meant to be the higher of two properties: 10+BAB+Wis and 10+Perception.
+        // The comparison is done correctly, but when Perception is the higher of the two the check
+        // still rolls against the 10+BAB+Wis property, making feints ~6 points easier than intended.
+        // Retarget the DC in that (IfFalse) branch to the Perception property.
+        var ability = BlueprintTool.Get<BlueprintAbility>(Guids.FeintAbility);
+        var perceptionDc = BlueprintTool.Get<BlueprintUnitProperty>(Guids.FeintDcPerceptionProperty)
+            .ToReference<BlueprintUnitPropertyReference>();
+
+        var swaps = 0;
+        foreach (var gate in ability.FlattenAllActions().OfType<Conditional>().Where(IsFeintDcComparison))
+        {
+            // The comparison is "BAB-DC >= Perception-DC"; its IfFalse branch is the "Perception is
+            // higher" case, whose checks wrongly use the BAB-DC property. Only that branch is walked,
+            // and only the check's DC is touched, so the comparison operands stay intact.
+            foreach (var check in FlattenActions(gate.IfFalse).OfType<ContextActionSkillCheck>()
+                         .Where(c => c.UseCustomDC
+                                     && c.CustomDC?.m_CustomProperty != null
+                                     && c.CustomDC.m_CustomProperty.deserializedGuid == Guids.FeintDcBabProperty))
+            {
+                check.CustomDC.m_CustomProperty = perceptionDc;
+                swaps++;
+            }
+        }
+
+        if (swaps == 6)
+        {
+            Main.log.Log("Fixed feint DC to use Perception when it is higher (swapped 6 checks).");
+        }
+        else
+        {
+            Main.log.Error($"Feint DC fix: expected to swap 6 DCs but swapped {swaps}.");
+        }
+    }
+
     // Final Feint is the top level of its subtree
     private static bool IsFinalFeintGate(Conditional conditional)
     {
@@ -88,6 +134,18 @@ public class SlayersFeintFix
                && conditional.ConditionsChecker.Conditions
                    .OfType<ContextConditionCasterHasFact>()
                    .Any(c => !c.Not && c.m_Fact != null && c.m_Fact.deserializedGuid == Guids.FinalFeintFact);
+    }
+
+    // This predicates a CheckCondition that accepts the BAB/Per arguments
+    private static bool IsFeintDcComparison(Conditional conditional)
+    {
+        return conditional.ConditionsChecker?.Conditions != null
+               && conditional.ConditionsChecker.Conditions
+                   .OfType<ContextConditionCompare>()
+                   .Any(c => c.CheckValue?.m_CustomProperty != null
+                             && c.TargetValue?.m_CustomProperty != null
+                             && c.CheckValue.m_CustomProperty.deserializedGuid == Guids.FeintDcBabProperty
+                             && c.TargetValue.m_CustomProperty.deserializedGuid == Guids.FeintDcPerceptionProperty);
     }
 
     // Equivalent to TTT's FlattenAllActions but startable from an arbitrary subtree

--- a/DragonFixes/Fixes/VariousFixes/SlayersFeint.cs
+++ b/DragonFixes/Fixes/VariousFixes/SlayersFeint.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using BlueprintCore.Utils;
+using DragonFixes.Util;
+using DragonLibrary.Utils;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
+using Kingmaker.UnitLogic.Mechanics.Actions;
+using TabletopTweaks.Core.Utilities;
+
+namespace DragonFixes.Fixes.VariousFixes;
+
+public class SlayersFeintFix
+{
+    [DragonConfigure]
+    public static void FixFeintCheckForCaster()
+    {
+        if (!Settings.GetSetting<bool>("feintcheckforcaster"))
+        {
+            Main.log.Log("Feint CheckForCaster patch disabled, skipping.");
+            return;
+        }
+        Main.log.Log("Fixing Slayer's Feint skill checks to roll for the caster instead of the target.");
+        // CheckForCaster = true makes the caster of the ability roll the check, not the target.
+        // Notably, this only happened For enemies that were more perceptive than BAB+Wis,
+        // but that's most of them...
+        var ability = BlueprintTool.Get<BlueprintAbility>(Guids.FeintAbility);
+        foreach (var check in ability.FlattenAllActions().OfType<ContextActionSkillCheck>())
+        {
+            check.CheckForCaster = true;
+        }
+    }
+}

--- a/DragonFixes/Fixes/VariousFixes/SlayersFeint.cs
+++ b/DragonFixes/Fixes/VariousFixes/SlayersFeint.cs
@@ -1,9 +1,16 @@
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using BlueprintCore.Utils;
 using DragonFixes.Util;
 using DragonLibrary.Utils;
+using Kingmaker.Blueprints;
+using Kingmaker.Designers.EventConditionActionSystem.Actions;
+using Kingmaker.ElementsSystem;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
+using Kingmaker.UnitLogic.Buffs.Blueprints;
 using Kingmaker.UnitLogic.Mechanics.Actions;
+using Kingmaker.UnitLogic.Mechanics.Conditions;
 using TabletopTweaks.Core.Utilities;
 
 namespace DragonFixes.Fixes.VariousFixes;
@@ -13,9 +20,9 @@ public class SlayersFeintFix
     [DragonConfigure]
     public static void FixFeintCheckForCaster()
     {
-        if (!Settings.GetSetting<bool>("feintcheckforcaster"))
+        if (!Settings.GetSetting<bool>("slayerfeintfix"))
         {
-            Main.log.Log("Feint CheckForCaster patch disabled, skipping.");
+            Main.log.Log("Slayer's Feint patch disabled, skipping.");
             return;
         }
         Main.log.Log("Fixing Slayer's Feint skill checks to roll for the caster instead of the target.");
@@ -26,6 +33,88 @@ public class SlayersFeintFix
         foreach (var check in ability.FlattenAllActions().OfType<ContextActionSkillCheck>())
         {
             check.CheckForCaster = true;
+        }
+    }
+
+    [DragonConfigure]
+    public static void FixFinalFeintMobilityMarker()
+    {
+        if (!Settings.GetSetting<bool>("slayerfeintfix"))
+        {
+            Main.log.Log("Slayer's Feint patch disabled, skipping.");
+            return;
+        }
+        // On the "Final Feint = true -> Slayer's Feint -> Mobility" path, FeintAbility applies the
+        // ordinary feint marker instead of the Final Feint marker, so the target is never made
+        // flat-footed to all attackers and the Final Feint benefit silently fails on that path
+        // (the Persuasion path is unaffected).
+        //
+        // When using Final Feint + Slayer's Feint AND Mobility is higher than Persuasion, the
+        // normal Feint debuff was applied instead of the Final Feint one.
+        //
+        // There's a lot of branches here though, so we need to be highly specific about which one
+        // to swap. Even then, we need to recurse deeper still.
+
+        var ability = BlueprintTool.Get<BlueprintAbility>(Guids.FeintAbility);
+        var ordinaryMarker = BlueprintTool.Get<BlueprintBuff>(Guids.FeintMarkerBuff);
+        var finalFeintMarker = BlueprintTool.Get<BlueprintBuff>(Guids.FinalFeintMarkerBuff)
+            .ToReference<BlueprintBuffReference>();
+
+        var swaps = 0;
+        foreach (var gate in ability.FlattenAllActions().OfType<Conditional>().Where(IsFinalFeintGate))
+        {
+            foreach (var apply in FlattenActions(gate.IfTrue).OfType<ContextActionApplyBuff>()
+                         .Where(a => a.Buff == ordinaryMarker))
+            {
+                apply.m_Buff = finalFeintMarker;
+                swaps++;
+            }
+        }
+
+        if (swaps == 2)
+        {
+            Main.log.Log("Fixed Final Feint marker on the Slayer's Feint Mobility path (swapped 2 buffs).");
+        }
+        else
+        {
+            Main.log.Error($"Final Feint marker fix: expected to swap 2 buffs but swapped {swaps}.");
+        }
+    }
+
+    // Final Feint is the top level of its subtree
+    private static bool IsFinalFeintGate(Conditional conditional)
+    {
+        return conditional.ConditionsChecker?.Conditions != null
+               && conditional.ConditionsChecker.Conditions
+                   .OfType<ContextConditionCasterHasFact>()
+                   .Any(c => !c.Not && c.m_Fact != null && c.m_Fact.deserializedGuid == Guids.FinalFeintFact);
+    }
+
+    // Equivalent to TTT's FlattenAllActions but startable from an arbitrary subtree
+    // (FlattenAllActions' recursive overload is not public).
+    private static IEnumerable<GameAction> FlattenActions(ActionList list)
+    {
+        if (list?.Actions == null)
+        {
+            yield break;
+        }
+        foreach (var action in list.Actions)
+        {
+            if (action == null)
+            {
+                continue;
+            }
+            yield return action;
+            foreach (var field in action.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (field.FieldType == typeof(ActionList))
+                {
+                    foreach (var nested in FlattenActions(field.GetValue(action) as ActionList))
+                    {
+                        yield return nested;
+                    }
+                }
+            }
         }
     }
 }

--- a/DragonFixes/Util/Guids.cs
+++ b/DragonFixes/Util/Guids.cs
@@ -15,5 +15,7 @@ namespace DragonFixes.Util
         public const string FinalFeintFact = "32429740d6a5470aaaa02f20d61e43d3";
         public const string FeintMarkerBuff = "e14f5e333e0e42fbbb7d7791c6072e7b";
         public const string FinalFeintMarkerBuff = "05c9dfa1595d48748c74316df97433c8";
+        public const string FeintDcBabProperty = "e7b2296d485e4c25b4c745d5a7fe42cb";
+        public const string FeintDcPerceptionProperty = "72fa876e4698445ca0dcb34ad390abab";
     }
 }

--- a/DragonFixes/Util/Guids.cs
+++ b/DragonFixes/Util/Guids.cs
@@ -12,5 +12,8 @@ namespace DragonFixes.Util
         public const string EbruptEndBuff = "A1E8FCB5-ECBD-43B1-B3B2-A5DF9B4E0E42";
         public const string DevitalizerBuff = "F39A6005-CF54-4C13-96EB-423FBE1EF7CB";
         public const string FeintAbility = "1bb6f0b196aa457ba80bdb312dc64952";
+        public const string FinalFeintFact = "32429740d6a5470aaaa02f20d61e43d3";
+        public const string FeintMarkerBuff = "e14f5e333e0e42fbbb7d7791c6072e7b";
+        public const string FinalFeintMarkerBuff = "05c9dfa1595d48748c74316df97433c8";
     }
 }

--- a/DragonFixes/Util/Guids.cs
+++ b/DragonFixes/Util/Guids.cs
@@ -11,5 +11,6 @@ namespace DragonFixes.Util
         public const string ESAccurayBuff = "017D75DE-44D1-40A8-A469-E242AB5E0131";
         public const string EbruptEndBuff = "A1E8FCB5-ECBD-43B1-B3B2-A5DF9B4E0E42";
         public const string DevitalizerBuff = "F39A6005-CF54-4C13-96EB-423FBE1EF7CB";
+        public const string FeintAbility = "1bb6f0b196aa457ba80bdb312dc64952";
     }
 }

--- a/DragonFixes/Util/Settings.cs
+++ b/DragonFixes/Util/Settings.cs
@@ -42,7 +42,7 @@ namespace DragonFixes.Util
                     .AddToggle(
                         Toggle.New(GetKey("scalykinddomain"), defaultValue: true, CreateString("scalykinddomain-toggle", "Fix Domain Zealot to work with Scalykind domain")))
                     .AddToggle(
-                        Toggle.New(GetKey("feintcheckforcaster"), defaultValue: true, CreateString("feintcheckforcaster-toggle", "Fix Slayer's Feint so the caster rolls the skill check against the target's DC, instead of the target rolling against itself")))
+                        Toggle.New(GetKey("slayerfeintfix"), defaultValue: true, CreateString("slayerfeintfix-toggle", "Fix Slayer's Feint: the caster rolls the skill check against the target's DC (instead of the target rolling against itself), and the Mobility path correctly applies the Final Feint marker so Slayer's + Final Feint works")))
                     .AddAnotherSettingsGroup(GetKey("kabfixes"), CreateString(GetKey("kab-fixes-title"), "Kab's Fixes"))
                     .AddToggle(
                         Toggle.New(GetKey("stinkycloud"), defaultValue: true, CreateString(GetKey("stinkycloud-toggle"), "Fix Stinking Cloud to only call for 1 save with TTT installed"))));

--- a/DragonFixes/Util/Settings.cs
+++ b/DragonFixes/Util/Settings.cs
@@ -41,6 +41,8 @@ namespace DragonFixes.Util
                         Toggle.New(GetKey("scalykind"), defaultValue: true, CreateString("scalykind-toggle", "Include Scalykind domain in the second domain selection")))
                     .AddToggle(
                         Toggle.New(GetKey("scalykinddomain"), defaultValue: true, CreateString("scalykinddomain-toggle", "Fix Domain Zealot to work with Scalykind domain")))
+                    .AddToggle(
+                        Toggle.New(GetKey("feintcheckforcaster"), defaultValue: true, CreateString("feintcheckforcaster-toggle", "Fix Slayer's Feint so the caster rolls the skill check against the target's DC, instead of the target rolling against itself")))
                     .AddAnotherSettingsGroup(GetKey("kabfixes"), CreateString(GetKey("kab-fixes-title"), "Kab's Fixes"))
                     .AddToggle(
                         Toggle.New(GetKey("stinkycloud"), defaultValue: true, CreateString(GetKey("stinkycloud-toggle"), "Fix Stinking Cloud to only call for 1 save with TTT installed"))));

--- a/DragonFixes/Util/Settings.cs
+++ b/DragonFixes/Util/Settings.cs
@@ -43,6 +43,8 @@ namespace DragonFixes.Util
                         Toggle.New(GetKey("scalykinddomain"), defaultValue: true, CreateString("scalykinddomain-toggle", "Fix Domain Zealot to work with Scalykind domain")))
                     .AddToggle(
                         Toggle.New(GetKey("slayerfeintfix"), defaultValue: true, CreateString("slayerfeintfix-toggle", "Fix Slayer's Feint: the caster rolls the skill check against the target's DC (instead of the target rolling against itself), and the Mobility path correctly applies the Final Feint marker so Slayer's + Final Feint works")))
+                    .AddToggle(
+                        Toggle.New(GetKey("feintdcfix"), defaultValue: true, CreateString("feintdcfix-toggle", "Fix the Feint DC: when the target's Perception-based DC (10 + Perception) is higher than its BAB-based DC (10 + BAB + WIS), the feint check now correctly rolls against the Perception DC instead of always using the lower BAB DC. Affects all feint sources, not just Slayer's Feint, and makes feinting appropriately harder.")))
                     .AddAnotherSettingsGroup(GetKey("kabfixes"), CreateString(GetKey("kab-fixes-title"), "Kab's Fixes"))
                     .AddToggle(
                         Toggle.New(GetKey("stinkycloud"), defaultValue: true, CreateString(GetKey("stinkycloud-toggle"), "Fix Stinking Cloud to only call for 1 save with TTT installed"))));


### PR DESCRIPTION
* Fixes Slayer's Feint to correctly use mobility of caster, not target
* Fixes Slayer's Feint + Final Feint interaction
* Fixes Feint using the wrong (lower) DC for checks - should be a ~3-6 bump on average perceptive enemies